### PR TITLE
Clean up controller

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -47,26 +47,13 @@ class CommentsController < ActionController::Base
   end
 
   private
-  
-  def classname
-     params.each do |name, value|
-      if name =~ /(.+)_id$/
-        return $1.classify.constantize
-      end
-    end
-  end
-
-  def model_id
-    params.each do |name, value|
-      if name =~ /.+_id$/
-        return name
-      end
-    end  
-    nil
-  end
 
   def get_model
-    @model = classname.find(params[model_id.to_sym])
+    @model = params.each do |name, value|
+      if name =~ /(.+)_id$/
+        return $1.classify.constantize.find(value)
+      end
+    end
   end
   
   def get_comment

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -42,7 +42,7 @@ class CommentsController < ActionController::Base
   end
 
   def destroy
-    @model.remove(params[:comment])
+    @model.comments.find(params[:id]).destroy
     respond_with(@model)
   end
 

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -51,7 +51,7 @@ class CommentsController < ActionController::Base
   def get_model
     @model = params.each do |name, value|
       if name =~ /(.+)_id$/
-        return $1.classify.camelize.find(value)
+        break $1.classify.camelize.find(value)
       end
     end
   end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -51,7 +51,7 @@ class CommentsController < ActionController::Base
   def get_model
     @model = params.each do |name, value|
       if name =~ /(.+)_id$/
-        return $1.classify.constantize.find(value)
+        return $1.classify.camelize.find(value)
       end
     end
   end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,7 +1,7 @@
 class CommentsController < ActionController::Base
   
   prepend_before_filter :get_model
-  before_filter :get_comment, :only => [:show, :edit, :update]
+  before_filter :get_comment, :only => [:show, :edit, :update, :destroy]
 
   respond_to :html
   
@@ -42,7 +42,7 @@ class CommentsController < ActionController::Base
   end
 
   def destroy
-    @model.comments.find(params[:id]).destroy
+    @comment.destroy
     respond_with(@model)
   end
 


### PR DESCRIPTION
Those two methods did mainly the same job twice. A quick rewrite, that could be further improved.

The class name is in the correct form already in the params, meaning all we need to do is to camelize it. If we use classify, we also do inflections, which can be incorrect ('Status' -> 'Statu')

destroy method actually deleted the entire parent document instead of erasing the document.
